### PR TITLE
Fix whatsapp alerts 500 error

### DIFF
--- a/backend/env.example
+++ b/backend/env.example
@@ -9,3 +9,9 @@ PORT=4000
 
 # CORS
 CORS_ORIGIN="http://localhost:5173"
+
+# Twilio (WhatsApp)
+TWILIO_ACCOUNT_SID=""
+TWILIO_AUTH_TOKEN=""
+# Ejemplo sandbox: 'whatsapp:+14155238886' (ajusta según tu número remitente aprobado)
+TWILIO_WHATSAPP_FROM="whatsapp:+14155238886"

--- a/backend/prisma/migrations/20250809045442_init/migration.sql
+++ b/backend/prisma/migrations/20250809045442_init/migration.sql
@@ -1,0 +1,18 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_User" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "email" TEXT NOT NULL,
+    "password" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "phoneNumber" TEXT,
+    "whatsappAlertsEnabled" BOOLEAN NOT NULL DEFAULT false,
+    "cotizacionesSeleccionadas" TEXT
+);
+INSERT INTO "new_User" ("createdAt", "email", "id", "password") SELECT "createdAt", "email", "id", "password" FROM "User";
+DROP TABLE "User";
+ALTER TABLE "new_User" RENAME TO "User";
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -18,6 +18,7 @@ model User {
   transacciones Transaccion[]
   phoneNumber String?   // Número de teléfono para alertas
   whatsappAlertsEnabled Boolean @default(false) // Preferencia de alerta
+  cotizacionesSeleccionadas String? // <-- Nuevo campo (puedes usar JSON.stringify)
 }
 
 model Servicio {
@@ -59,14 +60,4 @@ model Transaccion {
   user         User     @relation(fields: [userId], references: [id])
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
-}
-
-model User {
-  id           Int           @id @default(autoincrement())
-  email        String        @unique
-  password     String
-  createdAt    DateTime      @default(now())
-  servicios    Servicio[]
-  transacciones Transaccion[]
-  cotizacionesSeleccionadas String? // <-- Nuevo campo (puedes usar JSON.stringify)
 }

--- a/backend/src/lib/whatsapp.js
+++ b/backend/src/lib/whatsapp.js
@@ -6,32 +6,47 @@ const TWILIO_ACCOUNT_SID = process.env.TWILIO_ACCOUNT_SID;
 const TWILIO_AUTH_TOKEN = process.env.TWILIO_AUTH_TOKEN;
 const TWILIO_WHATSAPP_FROM = process.env.TWILIO_WHATSAPP_FROM; // Ej: 'whatsapp:+14155238886'
 
-const client = twilio(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN);
+let cachedClient = null;
+function getTwilioClient() {
+  if (!TWILIO_ACCOUNT_SID || !TWILIO_AUTH_TOKEN) {
+    return null;
+  }
+  if (cachedClient) return cachedClient;
+  try {
+    cachedClient = twilio(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN);
+    return cachedClient;
+  } catch (e) {
+    console.error('Error inicializando cliente de Twilio:', e?.message || e);
+    return null;
+  }
+}
 
 async function sendWhatsAppAlert(to, message) {
-    if (!TWILIO_ACCOUNT_SID || !TWILIO_AUTH_TOKEN || !TWILIO_WHATSAPP_FROM) {
-        throw new Error('Twilio config missing');
-    }
-    return client.messages.create({
-        from: TWILIO_WHATSAPP_FROM,
-        to: `whatsapp:${to}`,
-        body: message,
-    });
+  const client = getTwilioClient();
+  if (!client || !TWILIO_WHATSAPP_FROM) {
+    console.warn('Twilio config missing: no se enviará WhatsApp.');
+    return null;
+  }
+  return client.messages.create({
+    from: TWILIO_WHATSAPP_FROM,
+    to: `whatsapp:${to}`,
+    body: message,
+  });
 }
 
 // Verifica servicios vencidos y envía alerta si corresponde
 async function checkAndSendAlertsForUser(userId) {
-    const user = await prisma.user.findUnique({
-        where: { id: userId },
-        include: { servicios: true },
-    });
-    if (!user || !user.whatsappAlertsEnabled || !user.phoneNumber) return;
-    const vencidos = user.servicios.filter(s => s.estado === 'vencido');
-    if (vencidos.length === 0) return;
-    for (const servicio of vencidos) {
-        const msg = `¡Alerta! El servicio "${servicio.nombre}" está vencido. Monto: $${servicio.monto}. Vencimiento: ${servicio.vencimiento}`;
-        await sendWhatsAppAlert(user.phoneNumber, msg);
-    }
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    include: { servicios: true },
+  });
+  if (!user || !user.whatsappAlertsEnabled || !user.phoneNumber) return;
+  const vencidos = user.servicios.filter(s => s.estado === 'vencido');
+  if (vencidos.length === 0) return;
+  for (const servicio of vencidos) {
+    const msg = `¡Alerta! El servicio "${servicio.nombre}" está vencido. Monto: $${servicio.monto}. Vencimiento: ${servicio.vencimiento}`;
+    await sendWhatsAppAlert(user.phoneNumber, msg);
+  }
 }
 
 module.exports = { sendWhatsAppAlert, checkAndSendAlertsForUser };

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -139,6 +139,27 @@ router.post('/user/config', authenticateJWT, async (req, res) => {
   }
 });
 
+// Envío de WhatsApp de prueba con la configuración del usuario
+const { sendWhatsAppAlert } = require('../lib/whatsapp');
+router.post('/whatsapp/test', authenticateJWT, async (req, res) => {
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id: req.user.id },
+      select: { phoneNumber: true, whatsappAlertsEnabled: true }
+    });
+    if (!user) return res.status(404).json({ error: 'Usuario no encontrado' });
+    if (!user.whatsappAlertsEnabled) return res.status(400).json({ error: 'Las alertas de WhatsApp no están activadas' });
+    if (!user.phoneNumber) return res.status(400).json({ error: 'Número de teléfono no configurado' });
+
+    const result = await sendWhatsAppAlert(user.phoneNumber, 'Mensaje de prueba de PayBoard ✅');
+    const sent = !!result; // será null si no hay config Twilio
+    return res.json({ ok: true, sent, info: sent ? 'Mensaje enviado' : 'Twilio no está configurado, no se envió' });
+  } catch (err) {
+    console.error('Error en /api/auth/whatsapp/test:', err);
+    return res.status(500).json({ error: 'No se pudo enviar el mensaje de prueba' });
+  }
+});
+
 module.exports = router;
 
 


### PR DESCRIPTION
Fixes 500 error on user config endpoint and enables robust WhatsApp alerts by unifying the User model and adding a test endpoint.

The 500 error on `/api/auth/user/config` was caused by a duplicated `User` model in `schema.prisma` leading to database inconsistencies, and a fragile Twilio client setup that would throw errors if environment variables were missing. This PR unifies the `User` model, makes the Twilio client tolerant to missing config, and adds a `/api/auth/whatsapp/test` endpoint for verification.

---
<a href="https://cursor.com/background-agent?bcId=bc-e1d13066-8c29-4150-8ec3-0b65360b9cb6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e1d13066-8c29-4150-8ec3-0b65360b9cb6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

